### PR TITLE
Upgraded kotlin_version as required for Flutter 2.10.x

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'co.sunnyapp.flutter_contact'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.5.31'
     repositories {
         google()
         jcenter()

--- a/android/src/main/kotlin/co/sunnyapp/flutter_contact/FlutterContactFormsPluginOld.kt
+++ b/android/src/main/kotlin/co/sunnyapp/flutter_contact/FlutterContactFormsPluginOld.kt
@@ -12,7 +12,7 @@ class FlutterContactFormsOld(plugin: BaseFlutterContactPlugin, private val regis
 
     override fun startIntent(intent: Intent, request: Int) {
         if (registrar.activity() != null) {
-            registrar.activity().startActivityForResult(intent, request)
+            registrar.activity()!!.startActivityForResult(intent, request)
         } else {
             registrar.context().startActivity(intent)
         }


### PR DESCRIPTION
The latest stable version of Flutter 2.10.x requires kotlin version xxx or greater.

buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.5.31'


This requirement is described here:
https://docs.flutter.dev/release/breaking-changes/kotlin-version
